### PR TITLE
check if service exists before stopping

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -27,9 +27,14 @@
   tags:
     - node_packages
 
+- name: Check if Hubot Service Exists
+  stat: path=/etc/init.d/hubot
+  register: hubot_service_status
+
 - name: Stop Hubot service
   service: name=hubot state=stopped
-
+  when: hubot_service_status.stat.exists
+  
 - name: Decommission previous model
   sudo: True
   file: "path={{ hubot_dir }} state=absent"


### PR DESCRIPTION
When running the ansible playbook initially, it attempts to stop the hubot service which doesn't exist yet. With this patch it will check if the service exists first