### PR TITLE
added vagrant test install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+VAGRANT_VERSION = 2
+Vagrant.configure(VAGRANT_VERSION) do |config|
+	config.vm.define "hubot" do |server|
+		server.vm.box = "hashicorp/precise64"
+		server.vm.hostname = "hubot"
+		server.vm.provision :ansible do |ansible|
+			ansible.playbook = "test.yml"
+		end
+		#server.vm.network "forwarded_port", guest: 3000, host: 8080
+	end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+roles_path = ../:/etc/ansible/roles
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,3 +142,6 @@ hubot_ubuntu_os_packages:
   - libicu-dev
   - openssl
   - redis-server
+
+
+hubot_slack_token: EXAMPLE-zozb-7777777777-sybaOxAcybLo6U8suOhipCdR-EXAMPLE

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -57,7 +57,7 @@
 
 - name: Define Hubot environment
   sudo: False
-  template: "src=_hubot_{{hubot_adapter}}.env.j2 dest={{ hubot_dir }}/{{ hubot_identity }}.env"
+  template: "src=hubot_{{hubot_adapter}}.env.j2 dest={{ hubot_dir }}/{{ hubot_identity }}.env"
   tags:
     - hubot_environment
 

--- a/templates/hubot_slack.env.j2
+++ b/templates/hubot_slack.env.j2
@@ -6,4 +6,4 @@
 HUBOT_LOGLEVEL="info"
 
 # Slack stuff
-HUBOT_SLACK_TOKEN=EXAMPLE-zozb-7777777777-sybaOxAcybLo6U8suOhipCdR-EXAMPLE
+HUBOT_SLACK_TOKEN={{ hubot_slack_token }}

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,7 @@
+
+---
+- hosts: all
+  sudo: true
+  #requires the containing folder to be named hubot in order for the Vagrant provision to work correctly
+  roles:
+    - role: hubot


### PR DESCRIPTION
I find it helpful to "vagrant up" and "vagrant provision" to test ansible roles.  Added the basics to enable.  Also removed the underscore from the hubot_slack filename and inserted a variable.  If you have vagrant correctly installed and make sure the project folder is named "hubot" and not "ansible-hubot" it should run successfully on vagrant.
