### PR TITLE
These are Hubot scripts, not external scripts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,7 +131,7 @@ hubot_external_scripts:
 #
 #############################################################################
 
-# hubot_scripts:
+hubot_scripts:
   - achievement_unlocked.coffee
   - ackbar.coffee
   - applause.coffee


### PR DESCRIPTION
Having these listed as external scripts stops Hubot from running.